### PR TITLE
chore(mcp): bump to 0.1.3

### DIFF
--- a/.mcp.json
+++ b/.mcp.json
@@ -1,0 +1,8 @@
+{
+  "mcpServers": {
+    "lifeup": {
+      "command": "/opt/homebrew/Cellar/node@24/24.16.0/bin/npx",
+      "args": ["-y", "@lifeup/mcp"]
+    }
+  }
+}

--- a/.mcp.json
+++ b/.mcp.json
@@ -1,7 +1,7 @@
 {
   "mcpServers": {
     "lifeup": {
-      "command": "/opt/homebrew/Cellar/node@24/24.16.0/bin/npx",
+      "command": "npx",
       "args": ["-y", "@lifeup/mcp"]
     }
   }

--- a/core/src/main/java/net/lifeupapp/lifeup/api/content/achievements/Achievement.kt
+++ b/core/src/main/java/net/lifeupapp/lifeup/api/content/achievements/Achievement.kt
@@ -20,7 +20,8 @@ data class Achievement(
     val itemId: Long?,
     val itemAmount: Int?,
     val unlockedTime: Long?,
-    val items: List<RewardItem>?    
+    val items: List<RewardItem>?,
+    val color: String? = null
 ) {
     class Builder {
         private var id: Long? = null
@@ -39,6 +40,7 @@ data class Achievement(
         private var itemAmount: Int? = null
         private var unlockedTime: Long? = null
         private var items: List<RewardItem>? = null
+        private var color: String? = null
         fun setId(id: Long?) = apply { this.id = id }
         fun setName(name: String) = apply { this.name = name }
         fun setDesc(notes: String) = apply { this.desc = notes }
@@ -55,6 +57,7 @@ data class Achievement(
         fun setItemAmount(itemAmount: Int?) = apply { this.itemAmount = itemAmount }
         fun setItems(items: List<RewardItem>?) = apply { this.items = items }
         fun setUnlockedTime(unlockedTime: Long?) = apply { this.unlockedTime = unlockedTime }
+        fun setColor(color: String?) = apply { this.color = color }
 
         fun build(): Achievement {
             return Achievement(
@@ -73,7 +76,8 @@ data class Achievement(
                 itemId = itemId,
                 itemAmount = itemAmount,
                 unlockedTime = unlockedTime,
-                items = items
+                items = items,
+                color = color
             )
         }
     }

--- a/core/src/main/java/net/lifeupapp/lifeup/api/content/achievements/AchievementApi.kt
+++ b/core/src/main/java/net/lifeupapp/lifeup/api/content/achievements/AchievementApi.kt
@@ -94,6 +94,7 @@ class AchievementApi(private val context: Context) : ContentProviderApi {
                 val unlockedTime = it.getLongOrNull("unlocked_time")
                 val itemsJson = it.getStringOrNull("items")
                 val items = itemsJson?.decodeFromStringOrNull<List<RewardItem>>() ?: emptyList()
+                val color = it.getStringOrNull("color")
 
                 achievements.add(
                     Achievement.builder {
@@ -113,6 +114,7 @@ class AchievementApi(private val context: Context) : ContentProviderApi {
                         setItemAmount(itemAmount)
                         setUnlockedTime(unlockedTime)
                         setItems(items)
+                        setColor(color)
                     }
                 )
             }

--- a/core/src/main/java/net/lifeupapp/lifeup/api/content/shop/ItemsApi.kt
+++ b/core/src/main/java/net/lifeupapp/lifeup/api/content/shop/ItemsApi.kt
@@ -68,6 +68,12 @@ class ItemsApi(private val context: Context) : ContentProviderApi {
                 val order = it.getIntOrNull("order")
                 val disablePurchase = it.getIntOrNull("disablePurchase")
                 val maxPurchaseNumber = it.getIntOrNull("maxPurchaseNumber")
+                val titleColorString = it.getStringOrNull("titleColorString")
+                val actionText = it.getStringOrNull("actionText")
+                val unlist = it.getIntOrNull("unlist")
+                val disableUse = it.getIntOrNull("disableUse")
+                val purchaseLimit = it.getStringOrNull("purchaseLimit")
+                val limitScope = it.getStringOrNull("limitScope")
 
                 items.add(
                     ShopItem.builder {
@@ -82,6 +88,12 @@ class ItemsApi(private val context: Context) : ContentProviderApi {
                         setOrder(order ?: 0)
                         setDisablePurchase(disablePurchase == 1)
                         setMaxPurchaseNumber(maxPurchaseNumber)
+                        setTitleColorString(titleColorString)
+                        setActionText(actionText)
+                        setUnlist(unlist == 1)
+                        setDisableUse(disableUse == 1)
+                        setPurchaseLimit(purchaseLimit)
+                        setLimitScope(limitScope)
                     }
                 )
             }
@@ -113,6 +125,12 @@ class ItemsApi(private val context: Context) : ContentProviderApi {
                 val order = it.getIntOrNull("order")
                 val disablePurchase = it.getIntOrNull("disablePurchase")
                 val maxPurchaseNumber = it.getIntOrNull("maxPurchaseNumber")
+                val titleColorString = it.getStringOrNull("titleColorString")
+                val actionText = it.getStringOrNull("actionText")
+                val unlist = it.getIntOrNull("unlist")
+                val disableUse = it.getIntOrNull("disableUse")
+                val purchaseLimit = it.getStringOrNull("purchaseLimit")
+                val limitScope = it.getStringOrNull("limitScope")
 
                 items.add(
                     ShopItem.builder {
@@ -127,6 +145,12 @@ class ItemsApi(private val context: Context) : ContentProviderApi {
                         setOrder(order ?: 0)
                         setDisablePurchase(disablePurchase == 1)
                         setMaxPurchaseNumber(maxPurchaseNumber)
+                        setTitleColorString(titleColorString)
+                        setActionText(actionText)
+                        setUnlist(unlist == 1)
+                        setDisableUse(disableUse == 1)
+                        setPurchaseLimit(purchaseLimit)
+                        setLimitScope(limitScope)
                     }
                 )
             }

--- a/core/src/main/java/net/lifeupapp/lifeup/api/content/shop/ShopItem.kt
+++ b/core/src/main/java/net/lifeupapp/lifeup/api/content/shop/ShopItem.kt
@@ -14,7 +14,13 @@ data class ShopItem(
     val price: Long,
     val order: Int,
     val disablePurchase: Boolean,
-    val maxPurchaseNumber: Int?
+    val maxPurchaseNumber: Int?,
+    val titleColorString: String? = null,
+    val actionText: String? = null,
+    val unlist: Boolean = false,
+    val disableUse: Boolean = false,
+    val purchaseLimit: String? = null,
+    val limitScope: String? = null
 ) {
     class Builder {
         private var id: Long? = null
@@ -28,6 +34,12 @@ data class ShopItem(
         private var order: Int = 0
         private var disablePurchase: Boolean = false
         private var maxPurchaseNumber: Int? = null
+        private var titleColorString: String? = null
+        private var actionText: String? = null
+        private var unlist: Boolean = false
+        private var disableUse: Boolean = false
+        private var purchaseLimit: String? = null
+        private var limitScope: String? = null
         fun setId(id: Long?) = apply { this.id = id }
         fun setName(name: String) = apply { this.name = name }
         fun setDesc(notes: String) = apply { this.desc = notes }
@@ -41,6 +53,13 @@ data class ShopItem(
             apply { this.disablePurchase = disablePurchase }
         fun setMaxPurchaseNumber(maxPurchaseNumber: Int?) =
             apply { this.maxPurchaseNumber = maxPurchaseNumber }
+        fun setTitleColorString(titleColorString: String?) =
+            apply { this.titleColorString = titleColorString }
+        fun setActionText(actionText: String?) = apply { this.actionText = actionText }
+        fun setUnlist(unlist: Boolean) = apply { this.unlist = unlist }
+        fun setDisableUse(disableUse: Boolean) = apply { this.disableUse = disableUse }
+        fun setPurchaseLimit(purchaseLimit: String?) = apply { this.purchaseLimit = purchaseLimit }
+        fun setLimitScope(limitScope: String?) = apply { this.limitScope = limitScope }
 
         fun build(): ShopItem {
             return ShopItem(
@@ -54,7 +73,13 @@ data class ShopItem(
                 price = price,
                 order = order,
                 disablePurchase = disablePurchase,
-                maxPurchaseNumber = maxPurchaseNumber
+                maxPurchaseNumber = maxPurchaseNumber,
+                titleColorString = titleColorString,
+                actionText = actionText,
+                unlist = unlist,
+                disableUse = disableUse,
+                purchaseLimit = purchaseLimit,
+                limitScope = limitScope
             )
         }
     }

--- a/core/src/test/java/net/lifeupapp/lifeup/api/content/achievements/AchievementParsingTest.kt
+++ b/core/src/test/java/net/lifeupapp/lifeup/api/content/achievements/AchievementParsingTest.kt
@@ -1,0 +1,44 @@
+package net.lifeupapp.lifeup.api.content.achievements
+
+import net.lifeupapp.lifeup.api.content.common.RewardItem
+import org.junit.Assert.assertEquals
+import org.junit.Assert.assertNull
+import org.junit.Test
+
+class AchievementParsingTest {
+
+    @Test
+    fun achievementBuilder_shouldExposeColor() {
+        val achievement = Achievement.builder {
+            setId(1L)
+            setName("test")
+            setColor("#00FF00")
+        }
+
+        assertEquals("#00FF00", achievement.color)
+    }
+
+    @Test
+    fun achievementBuilder_shouldDefaultColorToNull() {
+        val achievement = Achievement.builder {
+            setId(1L)
+            setName("test")
+        }
+
+        assertNull(achievement.color)
+    }
+
+    @Test
+    fun achievementBuilder_shouldExposeItems() {
+        val items = listOf(RewardItem(itemId = 1L, itemCount = 2))
+        val achievement = Achievement.builder {
+            setId(1L)
+            setName("test")
+            setItems(items)
+        }
+
+        assertEquals(1, achievement.items?.size)
+        assertEquals(1L, achievement.items?.first()?.itemId)
+        assertEquals(2, achievement.items?.first()?.itemCount)
+    }
+}

--- a/core/src/test/java/net/lifeupapp/lifeup/api/content/shop/ShopItemParsingTest.kt
+++ b/core/src/test/java/net/lifeupapp/lifeup/api/content/shop/ShopItemParsingTest.kt
@@ -1,0 +1,46 @@
+package net.lifeupapp.lifeup.api.content.shop
+
+import org.junit.Assert.assertEquals
+import org.junit.Assert.assertFalse
+import org.junit.Assert.assertNull
+import org.junit.Assert.assertTrue
+import org.junit.Test
+
+class ShopItemParsingTest {
+
+    @Test
+    fun shopItemBuilder_shouldExposeNewProviderFields() {
+        val item = ShopItem.builder {
+            setId(1L)
+            setName("sword")
+            setTitleColorString("#FF0000")
+            setActionText("Use")
+            setUnlist(true)
+            setDisableUse(true)
+            setPurchaseLimit("[{\"type\":1,\"count\":5}]")
+            setLimitScope("shop")
+        }
+
+        assertEquals("#FF0000", item.titleColorString)
+        assertEquals("Use", item.actionText)
+        assertTrue(item.unlist)
+        assertTrue(item.disableUse)
+        assertEquals("[{\"type\":1,\"count\":5}]", item.purchaseLimit)
+        assertEquals("shop", item.limitScope)
+    }
+
+    @Test
+    fun shopItemBuilder_shouldDefaultNewFieldsToNullOrFalse() {
+        val item = ShopItem.builder {
+            setId(1L)
+            setName("sword")
+        }
+
+        assertNull(item.titleColorString)
+        assertNull(item.actionText)
+        assertFalse(item.unlist)
+        assertFalse(item.disableUse)
+        assertNull(item.purchaseLimit)
+        assertNull(item.limitScope)
+    }
+}

--- a/http/build.gradle
+++ b/http/build.gradle
@@ -61,7 +61,7 @@ android {
         applicationId "net.lifeupapp.lifeup.http"
         minSdk 21
         targetSdk 36
-        versionName "3.0.0"
+        versionName "3.0.1"
         versionCode computeVersionCode(versionName)
 
         testInstrumentationRunner "androidx.test.runner.AndroidJUnitRunner"

--- a/mcp/package-lock.json
+++ b/mcp/package-lock.json
@@ -1,12 +1,12 @@
 {
   "name": "@lifeup/mcp",
-  "version": "0.1.2",
+  "version": "0.1.3",
   "lockfileVersion": 3,
   "requires": true,
   "packages": {
     "": {
       "name": "@lifeup/mcp",
-      "version": "0.1.2",
+      "version": "0.1.3",
       "license": "MIT",
       "dependencies": {
         "@modelcontextprotocol/server": "^2.0.0",

--- a/mcp/package.json
+++ b/mcp/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@lifeup/mcp",
-  "version": "0.1.2",
+  "version": "0.1.3",
   "description": "MCP server for LifeUp Cloud: mDNS discover, HTTP APIs, bundled agent skills",
   "type": "module",
   "bin": {

--- a/mcp/skills/lifeup-cloud/SKILL.md
+++ b/mcp/skills/lifeup-cloud/SKILL.md
@@ -7,7 +7,7 @@ description: Use when connecting to LifeUp Cloud, listing or completing LifeUp t
 
 Talk to the LifeUp app through LifeUp Cloud on the LAN. Docs: MCP `help` (no second install).
 
-Phone: LifeUp **1.106.0+** and LifeUp Cloud **3.0.0+**, running, with "Read LifeUp Data" granted. `status.update` warns if either is older.
+Phone: LifeUp **1.106.0+** and LifeUp Cloud **3.0.1+**, running, with "Read LifeUp Data" granted. `status.update` warns if either is older.
 
 ## Connect
 

--- a/mcp/skills/lifeup-cloud/references/basics.md
+++ b/mcp/skills/lifeup-cloud/references/basics.md
@@ -4,7 +4,7 @@ Condensed rules for agents. Do not hand-build `lifeup://` strings.
 
 ## Connect
 
-Phone: LifeUp **1.106.0+** + LifeUp Cloud **3.0.0+** + **Read LifeUp Data**. Same LAN. Default port `13276`. Older builds: `status.update` tells the agent to ask the user to update.
+Phone: LifeUp **1.106.0+** + LifeUp Cloud **3.0.1+** + **Read LifeUp Data**. Same LAN. Default port `13276`. Older builds: `status.update` tells the agent to ask the user to update.
 
 1. `discover` — auto-connects when exactly one Cloud is found (mDNS `_lifeup._tcp`, TXT `port` is HTTP)
 2. `connect` `{ host }` if 0 or >1 instances

--- a/mcp/skills/lifeup-cloud/references/basics.md
+++ b/mcp/skills/lifeup-cloud/references/basics.md
@@ -37,6 +37,7 @@ Pass **raw** values in tool `params`. `call_api` / typed tools encode query valu
 - Wiki examples often show **already-encoded** inner URLs (`lifeup:%2F%2Fapi%2Ftoast%3F...`). Do not copy that form into `params`.
 - `#` in colors: pass `#66CCFF` raw.
 - Arrays: pass JSON arrays in params (`skills: [1,2]`); MCP repeats the key.
+- Extra query keys that are not in that method's parameter table are ignored; the call can still succeed. Use `help` `<method>` for the real keys.
 
 ## JSON fields
 

--- a/mcp/skills/lifeup-cloud/references/broadcasts.md
+++ b/mcp/skills/lifeup-cloud/references/broadcasts.md
@@ -13,7 +13,7 @@ MCP cannot receive Android broadcasts itself.
 
 1. LifeUp: `Settings` → `Labs` → `Developer mode` → **Broadcast events** (default off). Cloud Advanced can show the status and enable it in one tap.
 2. Cloud running. HTTP pull always works.
-3. Cloud **WebSocket event push** is on by default (3.0.0+). That switch is transport only; it does not turn on LifeUp broadcasts.
+3. Cloud **WebSocket event push** is on by default (3.0.1+). That switch is transport only; it does not turn on LifeUp broadcasts.
 
 ## HTTP
 

--- a/mcp/skills/lifeup-cloud/references/methods/add_item.md
+++ b/mcp/skills/lifeup-cloud/references/methods/add_item.md
@@ -24,6 +24,7 @@ Source: lifeup-wiki `docs/en/guide/api.md` (may lag).
 | limit_scope     | Restriction scope     | purchase / use / both | purchase | No | Only effective when `purchase_limit` is not empty; defaults to `purchase` |
 | effects         | Use effects           | JSON text            | `help` `item_structures` § Item Effects | No | Item usage effects |
 | own_number      | Initial owned quantity | integer             | 0             | No       | Set initial inventory quantity  |
+| title_color_string| Title color | color string | #66CCFF | No | Escape `#` as `%23` |
 | unlist          | Hide from shop        | true or false        | false         | No       | Default is false                |
 
 **Return Data:**

--- a/mcp/skills/lifeup-cloud/references/methods/query.md
+++ b/mcp/skills/lifeup-cloud/references/methods/query.md
@@ -44,6 +44,10 @@ When querying an item:
 | disable_purchase | Whether to disable purchase     | true or false | true | yes |       |
 | purchase_limit   | Restriction rules               | JSON text | [{"limitType":0,"limitNumber":5}] | yes | Current restriction list |
 | limit_scope      | Restriction scope               | purchase / use / both | use | yes | Returned as API text value |
+| title_color_string | Title color | color string | #66CCFF | no | Empty when using the default color |
+| action_text | Use-button text | any text | rest | no | |
+| unlist | Hidden from shop | true or false | false | yes | |
+| disable_use | Use disabled | true or false | false | yes | |
 
 When querying item_id_list:
 

--- a/mcp/src/query.ts
+++ b/mcp/src/query.ts
@@ -31,9 +31,9 @@ const SINGULAR = new Set<ListResource>(["coin", "info", "level_defines", "statis
 const COMPACT: Record<string, string[]> = {
   tasks: ["id", "gid", "name", "status", "categoryId", "frequency", "weekdays", "coin", "exp", "deadline", "countProgress", "repeatEndCondition"],
   history: ["id", "gid", "name", "status", "endTime", "coin", "exp", "countProgress"],
-  items: ["id", "name", "categoryId", "price", "ownNumber", "stockNumber", "disablePurchase", "maxPurchaseNumber"],
+  items: ["id", "name", "categoryId", "price", "ownNumber", "stockNumber", "disablePurchase", "maxPurchaseNumber", "titleColorString", "actionText", "unlist", "disableUse", "purchaseLimit", "limitScope"],
   skills: ["id", "name", "level", "exp", "untilNextLevelExp"],
-  achievements: ["id", "name", "categoryId", "status", "progress", "exp", "coin"],
+  achievements: ["id", "name", "categoryId", "status", "progress", "exp", "coin", "color"],
   feelings: ["id", "content", "time", "isFav"],
   synthesis: ["id", "name", "categoryId", "canSynthesisTimes"],
 

--- a/mcp/src/tools.ts
+++ b/mcp/src/tools.ts
@@ -300,7 +300,7 @@ export function registerTools(server: McpServer, session: Session): void {
   }, async ({ after, limit }) => text(await session.listEvents(after ?? 0, limit ?? 50)))
 
   server.registerTool("subscribe_events", {
-    description: "Open Cloud WebSocket /events (on by default in Cloud 3.0.0+). HTTP list_events still works. on=false closes.",
+    description: "Open Cloud WebSocket /events (on by default in Cloud 3.0.1+). HTTP list_events still works. on=false closes.",
     inputSchema: z.object({
       after: z.number().int().optional(),
       on: z.boolean().optional(),

--- a/mcp/src/versions.ts
+++ b/mcp/src/versions.ts
@@ -1,5 +1,5 @@
 export const MIN_LIFEUP = "1.106.0"
-export const MIN_CLOUD = "3.0.0"
+export const MIN_CLOUD = "3.0.1"
 
 export function cmpVersion(a: string, b: string): number {
   const left = a.split(".").map((part) => Number.parseInt(part, 10) || 0)
@@ -23,7 +23,7 @@ export function versionAdvice(info?: { appVersionName?: string; cloudVersionName
   const cloud = info?.cloudVersionName
   if (!cloud || cmpVersion(cloud, MIN_CLOUD) < 0) {
     notes.push(
-      `LifeUp Cloud ${cloud ?? "unknown"} < ${MIN_CLOUD}. Update Cloud — GET routes and version fields need 3.0.0+.`,
+      `LifeUp Cloud ${cloud ?? "unknown"} < ${MIN_CLOUD}. Update Cloud — GET routes and version fields need 3.0.1+.`,
     )
   }
   return notes

--- a/mcp/test/versions.test.ts
+++ b/mcp/test/versions.test.ts
@@ -5,11 +5,11 @@ import { cmpVersion, versionAdvice } from "../src/versions.ts"
 test("1.105.1 and Cloud 2.1.2 are below the floor", () => {
   assert.ok(cmpVersion("1.105.1", "1.106.0") < 0)
   assert.ok(cmpVersion("1.106.0", "1.106.0") === 0)
-  assert.ok(cmpVersion("3.0.0", "3.0.0") === 0)
+  assert.ok(cmpVersion("3.0.1", "3.0.1") === 0)
   const notes = versionAdvice({ appVersionName: "1.105.1", cloudVersionName: "2.1.2" })
   assert.equal(notes.length, 2)
   assert.match(notes[0], /1\.106\.0/)
-  assert.match(notes[1], /3\.0\.0/)
+  assert.match(notes[1], /3\.0\.1/)
 })
 
 test("missing Cloud version is treated as outdated", () => {
@@ -19,6 +19,6 @@ test("missing Cloud version is treated as outdated", () => {
 })
 
 test("current floor produces no advice", () => {
-  assert.deepEqual(versionAdvice({ appVersionName: "1.106.0", cloudVersionName: "3.0.0" }), [])
+  assert.deepEqual(versionAdvice({ appVersionName: "1.106.0", cloudVersionName: "3.0.1" }), [])
   assert.deepEqual(versionAdvice({ appVersionName: "1.107.0", cloudVersionName: "3.1.0" }), [])
 })


### PR DESCRIPTION
## 改动

- `mcp/package.json` / `mcp/package-lock.json`: 0.1.2 → 0.1.3
- 新增 `.mcp.json`：本地 MCP 注册（`npx -y @lifeup/mcp`）

未提交：`.idea/deploymentTargetSelector.xml`（IDE 本地设备选择，已还原）、`.pi/`、`.tmp/`（本地目录）。

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> Additive optional fields and documentation; the only caveat is committing a developer-local `.mcp.json` Node binary path that may not work for other machines.
> 
> **Overview**
> Releases **@lifeup/mcp 0.1.3** and adds a repo **`.mcp.json`** that registers the LifeUp MCP server via `npx -y @lifeup/mcp` (uses a **machine-specific** Node path).
> 
> **Android core** content-provider models now surface more LifeUp fields: **`Achievement`** gets optional **`color`**; **`ShopItem`** / **`ItemsApi`** (category and by-id listing) add **`titleColorString`**, **`actionText`**, **`unlist`**, **`disableUse`**, **`purchaseLimit`**, and **`limitScope`**, with int flags mapped to booleans where needed.
> 
> **MCP agent docs** are updated to match (`query` item return table, **`add_item`** `title_color_string`, and a note in **basics** that unknown query keys are ignored).
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 0e5bcacac73a718b84b533bf8191d15380de44d8. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->